### PR TITLE
Update schedule to run biweekly

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,8 +1,8 @@
-name: Daily Accessibility Report
+name: Bi-weekly Accessibility Report
 
 on:
   schedule:
-  - cron: '0 3 * * *' # Runs every day at 03:00 UTC
+  - cron: '0 3 1,15 * *' # Runs on the 1st and 15th of each month at 03:00 UTC
   workflow_dispatch:
 
 


### PR DESCRIPTION
## Summary
- tweak workflow to run on the 1st and 15th of each month
- rename workflow to **Bi-weekly Accessibility Report**

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685547d63d8c832694cd23a31a084dfa