### PR TITLE
Update report pagination after generating new report

### DIFF
--- a/src/generateReport.ts
+++ b/src/generateReport.ts
@@ -537,6 +537,11 @@ export function main(reportDate?: string) {
 `;
 
   fs.writeFileSync(path.join(docsRoot, "index.html"), indexHtml, "utf-8");
+
+  if (!reportDate && prevReportDir) {
+    // Update previous report so its forward navigation points to this one
+    main(prevReportDir);
+  }
 }
 
 // If run directly, call main() for today


### PR DESCRIPTION
## Summary
- regenerate the previous report when a new one is generated so navigation arrows stay in sync

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run report` *(fails: No report found for this date. Run an audit first.)*


------
https://chatgpt.com/codex/tasks/task_e_689356567fec8326b89eb0ed3f414ae5